### PR TITLE
Support defsharp syntax highlighting

### DIFF
--- a/indent/hy.vim
+++ b/indent/hy.vim
@@ -39,7 +39,7 @@ setlocal lispwords+=loop,for*,while
 
 " hyDefine
 setlocal lispwords+=defmacro/g!,defmain,defn-alias,defun-alias,defmulti,defnc
-setlocal lispwords+=defclass,defmacro,defreader,defn,defun
+setlocal lispwords+=defclass,defmacro,defreader,defsharp,defn,defun
 
 " hyMacro
 setlocal lispwords+=,->,->>,ap-dotimes,ap-each,ap-each-while,ap-filter,ap-first

--- a/indent/hy_indent.hy
+++ b/indent/hy_indent.hy
@@ -1,7 +1,7 @@
 (import vim)
 
 (defn vimfns (object))
-(defreader v [name]
+(defsharp v [name]
   `(do
      (unless (hasattr vimfns ~name)
        (setattr vimfns ~name (vim.Function ~name)))

--- a/syntax/hy.vim
+++ b/syntax/hy.vim
@@ -19,7 +19,7 @@ syntax keyword hySpecial macro-error defmacro-alias let if-python2 def setv fn l
 syntax keyword hyException throw raise try except catch
 syntax keyword hyCond cond if-not lisp-if lif when unless
 syntax keyword hyRepeat loop for* while
-syntax keyword hyDefine defmacro/g! defmain defn-alias defun-alias defmulti defnc defclass defmacro defreader defn defun
+syntax keyword hyDefine defmacro/g! defmain defn-alias defun-alias defmulti defnc defclass defmacro defreader defsharp defn defun
 syntax keyword hyMacro for with car cdr -> ->> with-gensyms ap-if ap-each ap-each-while ap-map ap-map-when ap-filter ap-reject ap-dotimes ap-first ap-last ap-reduce defnc fnc fnr route-with-methods route post-route put-route delete-route profile/calls profile/cpu walk postwalk prewalk macroexpand-all
 syntax keyword hyFunc curry --trampoline-- recursive-replace _numeric-check coll? cons cons? keyword? dec disassemble distinct drop empty? even? every? fake-source-positions flatten _flatten float? gensym calling-module-name first identity inc instance? integer integer? integer-char? iterable? iterate iterator? list* macroexpand macroexpand-1 neg? none? nil? numeric? nth odd? pos? remove rest repeatedly second some string string? take take-nth zero? list quote quasiquote unquote unquote-splicing eval do progn if break print continue assert global yield yield-from from import get . del slice assoc with-decorator with* , list-comp set-comp dict-comp genexpr apply not ~ require and or = != < <= > >= is in is-not not-in % / // ** << >> ^ & + * - += /= //= *= -= %= **= <<= >>= ^= &= HyExpression HyList dispatch-reader-macro eval-and-compile eval-when-compile HyCons HyInteger HyFloat HyComplex HySymbol HyString HyKeyword
 " Not used at this moment


### PR DESCRIPTION
Small PR to replace the `defrecord` with `defsharp` in `hy_indent.hy`, and add `defsharp` keyword to vim's highlight list.