### PR TITLE
Update `deftag v ...` to `defmacro "#v" ...`

### DIFF
--- a/indent/hy_indent.hy
+++ b/indent/hy_indent.hy
@@ -1,7 +1,7 @@
 (import vim)
 
 (defn vimfns [] (object))
-(deftag v [name]
+(defmacro "#v" [name]
   `(do
      (unless (hasattr vimfns ~name)
        (setattr vimfns ~name (vim.Function ~name)))


### PR DESCRIPTION
Hy 1.0 drops `deftag foo ...` and replaces it with `defmacro "#foo" ...`. This updates the code in vim-hy to match the new syntax.

Resolves #23 