### PR TITLE
Allow most* bracket strings with delimiters to retain highlighting

### DIFF
--- a/syntax/hy.vim
+++ b/syntax/hy.vim
@@ -96,7 +96,7 @@ syntax match hyKeyword "\v<:{1,2}%([^ \n\r\t()\[\]{}";@^`~\\%/]+/)*[^ \n\r\t()\[
 syntax match hyStringEscape "\v\\%([\\abfnrtv'"]|[0-3]\o{2}|\o{1,2}|x\x{2}|u\x{4}|U\x{8}|N\{[^}]*\})" contained
 
 syntax region hyString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=hyStringEscape
-syntax region hyString start="#\[\[" skip=/\\\\\|\\"/ end="\]\]" contains=hyStringEscape
+syntax region hyString start="#\[\z(.*\)\[" skip=/\\\\\|\\"/ end="\]\z1\]" contains=hyStringEscape
 
 syntax match hyCharacter "\\."
 syntax match hyCharacter "\\o\%([0-3]\o\{2\}\|\o\{1,2\}\)"

--- a/syntax/hy.vim
+++ b/syntax/hy.vim
@@ -96,7 +96,7 @@ syntax match hyKeyword "\v<:{1,2}%([^ \n\r\t()\[\]{}";@^`~\\%/]+/)*[^ \n\r\t()\[
 syntax match hyStringEscape "\v\\%([\\abfnrtv'"]|[0-3]\o{2}|\o{1,2}|x\x{2}|u\x{4}|U\x{8}|N\{[^}]*\})" contained
 
 syntax region hyString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=hyStringEscape
-syntax region hyString start="#\[\z(.*\)\[" skip=/\\\\\|\\"/ end="\]\z1\]" contains=hyStringEscape
+syntax region hyString start="#\[\z(.\{-}\)\[" skip="#" end="\]\z1\]" contains=hyString keepend
 
 syntax match hyCharacter "\\."
 syntax match hyCharacter "\\o\%([0-3]\o\{2\}\|\o\{1,2\}\)"


### PR DESCRIPTION
as of now, only bracket strings with no limiter (eg: `#[[aoeu]]`) get highlighted as a `hyString`. strings containing delimiters (eg: `#[foo[aoeu]foo]` do not get highlighted as a `hyString`. this pull request fixes that, for the most part.

currently, delimited bracket strings not receiving the proper highlighting causes a variety of issues:
- strings containing `;` get highlighted as though everything after `;` is a comment.
- keywords in strings get highlighted as though they are keywords.
- if `g:hy_enable_conceal` is `1`, items within a string that would be concealed otherwise get concealed.
- if a user has some plugin to color brackets/parens in matching pairs, any such characters appearing in a string will throw off the colors of the remaining brackets in the file.

these issues are demonstrated as follows:
![image](https://github.com/user-attachments/assets/a0ee9308-4fa6-43a2-95ce-4c5f5ddda0a8)

with the modifications herein, these issues are almost entirely solved:
![image](https://github.com/user-attachments/assets/0a1a13a9-974b-4b8c-95f3-f853b68e0b0a)
as can be seen above, all strings with matching delimiters are appropriately highlighted as `hyString`.

\* excluding bracket strings with newlines inside their delimiters, because
> Note that only matches within a single line can be used.  Multi-line matches
cannot be referred to.
https://vimhelp.org/syntax.txt.html#%3Asyn-ext-match

the number of bracket strings whose delimiter includes a newline in any code anywhere must be very small, thus this is judged to be minimally consequential.