### PR TITLE
feat: Update lispwords for Hyrule 1.0.0

### DIFF
--- a/ftplugin/hy.vim
+++ b/ftplugin/hy.vim
@@ -19,13 +19,13 @@ setlocal lispwords=let,if,when,while,for,lfor,dfor,gfor,sfor,with,match,try,
 			\defn,fn,defmacro,defreader,defclass,except,except*
 "
 " Hyrule lispwords:
-" http://hylang.org/hyrule/doc/v0.6.0
+" http://hylang.org/hyrule/doc/v1.0.0
 " same rule as above
 setlocal lispwords+=ap-if,ap-each,ap-each-while,ap-dotimes,ap-when,ap-with,
 			\->,->>,as->,some->,doto,block,branch,case,cfor,
 			\defmain,do-n,ebranch,ecase,list-n,loop,unless,defn+,
-			\defn/a+,fn+,fn/a+,let+,defmacro-kwargs,defmacro!,
-			\with-gensyms,seq,defseq,smacrolet
+			\fn+,let+,defmacro-kwargs,defmacro!,lif,ncut,setv+,
+			\seq,defseq,smacrolet,ameth,meth
 
 " Use two semicolons: The Hy style guide recommends a single semicolon for
 " margin comments only.


### PR DESCRIPTION
Remove macros that no longer exist in current Hyrule:
- defn/a+, fn/a+ (async variants removed)
- with-gensyms (removed; replaced by def-gensyms in syntax)

Add new Hyrule macros with special first arguments:
- lif (Lispy if; condition/result pairs)
- ncut (n-dimensional slice; first arg is target sequence)
- setv+ (destructured assignment; first arg is binding pair)
- ameth (async method definition; first arg is method name)
- meth (method definition; first arg is method name)

Update doc URL to Hyrule v1.0.0.